### PR TITLE
Auto-escape: no escaping if passed a certain class

### DIFF
--- a/Zend/zend.c
+++ b/Zend/zend.c
@@ -104,6 +104,7 @@ ZEND_INI_BEGIN()
 	STD_ZEND_INI_BOOLEAN("zend.enable_gc",				"1",	ZEND_INI_ALL,		OnUpdateGCEnabled,      gc_enabled,     zend_gc_globals,        gc_globals)
 	STD_ZEND_INI_BOOLEAN("__auto_escape",			"0",	ZEND_INI_ALL,	   OnUpdateBool,				__auto_escape,            zend_executor_globals, executor_globals)
 	STD_ZEND_INI_ENTRY("__auto_escape_flags",			"3",	ZEND_INI_ALL,		OnUpdateLong,			__auto_escape_flags,      zend_executor_globals, executor_globals)
+	STD_ZEND_INI_ENTRY("__auto_escape_exempt_class","",	ZEND_INI_ALL,		OnUpdateString,		__auto_escape_exempt_class,zend_executor_globals,executor_globals)
  	STD_ZEND_INI_BOOLEAN("zend.multibyte", "0", ZEND_INI_PERDIR, OnUpdateBool, multibyte,      zend_compiler_globals, compiler_globals)
  	ZEND_INI_ENTRY("zend.script_encoding",			NULL,		ZEND_INI_ALL,		OnUpdateScriptEncoding)
  	STD_ZEND_INI_BOOLEAN("zend.detect_unicode",			"1",	ZEND_INI_ALL,		OnUpdateBool, detect_unicode, zend_compiler_globals, compiler_globals)
@@ -342,7 +343,8 @@ ZEND_API int zend_print_zval_ex(zend_write_func_t write_func, zval *expr, int in
 
 ZEND_API int zend_print_zval_escape(zval *expr, int indent) /* {{{ */
 {
-	if (EG(__auto_escape)) {
+	// If this is an instance of our special HTML string
+	if (EG(__auto_escape) && !(Z_TYPE_P(expr) == IS_OBJECT && strcmp(Z_OBJ_CLASS_NAME_P(expr), EG(__auto_escape_exempt_class)) == 0)) {
 		return zend_print_zval_ex(escape_write, expr, indent);
 	} else {
 		return zend_print_zval_ex(zend_write, expr, indent);

--- a/Zend/zend_globals.h
+++ b/Zend/zend_globals.h
@@ -259,6 +259,7 @@ struct _zend_executor_globals {
 
 	zend_bool __auto_escape;
 	long __auto_escape_flags;
+	char *__auto_escape_exempt_class;
 	void *reserved[ZEND_MAX_RESERVED_RESOURCES];
 };
 

--- a/php.ini-development
+++ b/php.ini-development
@@ -852,6 +852,12 @@ default_socket_timeout = 60
 ; Default is ENT_QUOTES == 3
 ;__auto_escape_flags = 3
 
+; When using __auto_escape, if an instance of a class with this name
+; is outputted to short tags <?= $obj ?> its toString() will not be escaped and
+; will be passed directly to stdout.
+; Default is ""
+;__auto_escape_exempt_class = "HtmlString"
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ; Dynamic Extensions ;
 ;;;;;;;;;;;;;;;;;;;;;;

--- a/php.ini-production
+++ b/php.ini-production
@@ -852,6 +852,12 @@ default_socket_timeout = 60
 ; Default is ENT_QUOTES == 3
 ;__auto_escape_flags = 3
 
+; When using __auto_escape, if an instance of a class with this name
+; is outputted to short tags <?= $obj ?> its toString() will not be escaped and
+; will be passed directly to stdout.
+; Default is ""
+;__auto_escape_exempt_class = "HtmlString"
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ; Dynamic Extensions ;
 ;;;;;;;;;;;;;;;;;;;;;;

--- a/tests/lang/short_tags.006.phpt
+++ b/tests/lang/short_tags.006.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Auto-escaping with __auto_escape_exempt_class using short open tags __auto_escape: On
+--INI--
+short_open_tag=on
+__auto_escape=Off
+__auto_escape_exempt_class=HtmlString
+--FILE--
+<? 
+class HtmlString {
+    protected $html = '';
+ 
+    public function __construct($html) {
+       $this->html = $html;
+    }
+ 
+    public function __toString() {
+       return $this->html;
+    }
+}
+?>
+<?= "this ampersand shouldn't be escaped: &" ?>
+
+<? ini_set("__auto_escape", 1) ?>
+<?= "   this ampersand should be escaped: &" ?>
+
+<?= new HtmlString("this ampersand shouldn't be escaped: &") ?>
+<? ini_set("__auto_escape_exempt_class", "No Such Class") ?>
+
+<?= new HtmlString("   this ampersand should be escaped: &") ?>
+--EXPECT--
+this ampersand shouldn't be escaped: &
+   this ampersand should be escaped: &amp;
+this ampersand shouldn't be escaped: &
+   this ampersand should be escaped: &amp;


### PR DESCRIPTION
If an object that is an instance of a class with a name matching the
ini setting (__auto_escape_exempt_class) is passed through short-tags it
_won't_ be escaped.

This effectively allows strings to be _tagged_ (wrapped in a class) as
containing HTML and still used as normal without having to use <?raw=.
This encourages tagging strings as containing HTML where they are
generated rather than where they are outputted. The eliminates the need
for developers to trace that info (html or not) from generation site to
usage in a template.

Note: classname is used instead of class inheritance because this is an
often-executed piece of code.

``` php
ini_set("__auto_escape_exempt_class", "HtmlString");

// ======== Helper functions
function input_tag($options = []) {
   // ...
   return new HtmlString("<input ..></input>");
}

function user_name() {
   return $user->name;
}

// ========= Template
<?= input_tag() ?> // Wrapped in HTMLString == not escaped
<?= user_name() ?> // Regular string == escaped
```

_Note: This actually removes the need for `<?raw=` which will be dealt with in a future pull._
