### PR TITLE
POST requests: remove extraneous copying

### DIFF
--- a/main/php_content_types.c
+++ b/main/php_content_types.c
@@ -37,32 +37,13 @@ static sapi_post_entry php_post_entries[] = {
  */
 SAPI_API SAPI_POST_READER_FUNC(php_default_post_reader)
 {
-	char *data;
-	int length;
-
-	/* $HTTP_RAW_POST_DATA registration */
-	if (!strcmp(SG(request_info).request_method, "POST")) {
-		if (NULL == SG(request_info).post_entry) {
-			/* no post handler registered, so we just swallow the data */
-			sapi_read_standard_form_data(TSRMLS_C);
-		}
-
-		/* For unknown content types we create HTTP_RAW_POST_DATA even if always_populate_raw_post_data off,
-		 * this is in-effecient, but we need to keep doing it for BC reasons (for now) */
-		if ((PG(always_populate_raw_post_data) || NULL == SG(request_info).post_entry) && SG(request_info).post_data) {
-			length = SG(request_info).post_data_length;
-			data = estrndup(SG(request_info).post_data, length);
-			SET_VAR_STRINGL("HTTP_RAW_POST_DATA", data, length);
-		}
-	}
-
 	/* for php://input stream:
 	 some post handlers modify the content of request_info.post_data
 	 so for now we need a copy for the php://input stream
 	 in the long run post handlers should be changed to not touch
 	 request_info.post_data for memory preservation reasons
 	*/
-	if (SG(request_info).post_data) {
+	if (SG(request_info).post_data && NULL != SG(request_info).post_entry) {
 		SG(request_info).raw_post_data = estrndup(SG(request_info).post_data, SG(request_info).post_data_length);
 		SG(request_info).raw_post_data_length = SG(request_info).post_data_length;
 	}


### PR DESCRIPTION
`post_max_size` limits the size of the traditional upload process used
by older browsers. We'd like to have that set as high as possible,
BUT...

If php receives a POST request that is less than `post_max_size` and
it comes from a modern browser (the content type is anything other
than `multipart/form-data`), php would previously run inneficient code
that copied the request body several times for backward compatability
reasons.  This needed roughly `3 * $filesize` bytes of on-heap memory
for a given upload.  This effectively is a tradeoff, set
`post_max_size` high and modern browsers start making php run out of
memory, set it low and older browsers can't upload big files.

A new commit in php-5.6 removes this old code along with a bunch of
other stuff. See:
https://github.com/php/php-src/commit/2438490addfbfba51e12246a74588b2382caa08a
We can't jut apply this patch whole-sale cause we don't know what else
it depends on. Eventually we'll use 5.6 and this change won't be
necessary.

This simply removes the old code that copies the body several times
and only restores `raw_post_data` (for reading from stdin) when one of
php's content type parsers reads the whole body.
